### PR TITLE
Initial version of github action building and pushing the container

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,0 +1,64 @@
+name: Build and Deploy Container
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tag
+        run: |
+          if [ "${{ github.ref_type }}" == "tag" ]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          else
+            echo "tag=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Determine full image reference
+        run: |
+          echo "imgref=ghcr.io/${{ github.repository_owner }}/fedora-buildroot-riscv64-41:${{ env.tag }}" >> $GITHUB_ENV
+
+      - name: Set up QEMU for cross-arch building
+        uses: docker/setup-qemu-action@v2
+
+      # fedora.riscv.rocks:3000 runs HTTP
+      - name: Configure Docker to allow HTTP registry
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{ "insecure-registries":["fedora.riscv.rocks:3000"] }' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
+      - name: Build and push container
+        uses: docker/build-push-action@v5
+        with:
+          context: fedora-buildroot-riscv64-41
+          platforms: linux/riscv64
+          file: fedora-buildroot-riscv64-41/Containerfile
+          push: true
+          tags: ${{ env.imgref }}
+
+      - name: Summary
+        run: >-
+          echo "You can pull with podman or docker: e.g.
+          podman pull --platform linux/riscv64 ${{ env.imgref }}"
+

--- a/fedora-buildroot-riscv64-41/Containerfile
+++ b/fedora-buildroot-riscv64-41/Containerfile
@@ -6,7 +6,8 @@ COPY fedora-riscv-workaround.repo /etc/yum.repos.d/fedora-riscv-workaround.repo
 
 # ostree is only here because our BuildrotoFromContainer hardcodes it,
 # c.f. https://github.com/osbuild/images/blob/v0.118.0/pkg/manifest/build.go#L216
-RUN dnf install -y \
+# Setting timeout and retries to be graceful with slow mirrors
+RUN dnf install -y --setopt=timeout=120 --setopt=retries=10 \
     selinux-policy-targeted \
     policycoreutils \
     dosfstools \

--- a/fedora-buildroot-riscv64-41/Containerfile
+++ b/fedora-buildroot-riscv64-41/Containerfile
@@ -2,13 +2,7 @@ FROM fedora.riscv.rocks:3000/davidlt/fedora-toolbox:41
 
 # repos are now incremental but container was not updated yet,
 # workaround this here
-RUN cat <<EOF > /etc/yum.repos.d/fedora-riscv-workaround.repo
-[fedira-riscv-non-staging]
-name=Fedora RISC-V
-baseurl=http://fedora.riscv.rocks/repos-dist/f41/latest/riscv64/
-enabled=1
-gpgcheck=0
-EOF
+COPY fedora-riscv-workaround.repo /etc/yum.repos.d/fedora-riscv-workaround.repo
 
 # ostree is only here because our BuildrotoFromContainer hardcodes it,
 # c.f. https://github.com/osbuild/images/blob/v0.118.0/pkg/manifest/build.go#L216

--- a/fedora-buildroot-riscv64-41/fedora-riscv-workaround.repo
+++ b/fedora-buildroot-riscv64-41/fedora-riscv-workaround.repo
@@ -1,0 +1,6 @@
+[fedira-riscv-non-staging]
+name=Fedora RISC-V
+baseurl=http://fedora.riscv.rocks/repos-dist/f41/latest/riscv64/
+enabled=1
+gpgcheck=0
+


### PR DESCRIPTION
Initial version of github action building and pushing the container

I think we could also restrict to build only on changes in this folder if needed

```
on:
  push:
    branches:
      - main
    paths:
      - 'fedora-buildroot-riscv64-41/**'
…
```

@mvo5 please check if this is what you need

Examples:
Tag build:
https://github.com/schuellerf/buildroot-containers/actions/runs/13528088059

Manual run:
https://github.com/schuellerf/buildroot-containers/actions/runs/13528019439
