### PR TITLE
github/workflows/build_container: add building date-tag

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -34,9 +34,13 @@ jobs:
             echo "tag=latest" >> $GITHUB_ENV
           fi
 
-      - name: Determine full image reference
+      - name: Set timestamp tag
+        run: echo "timestamp=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+
+      - name: Determine full image references
         run: |
           echo "imgref=ghcr.io/${{ github.repository_owner }}/fedora-buildroot-riscv64-41:${{ env.tag }}" >> $GITHUB_ENV
+          echo "imgrefdate=ghcr.io/${{ github.repository_owner }}/fedora-buildroot-riscv64-41:${{ env.timestamp }}" >> $GITHUB_ENV
 
       - name: Set up QEMU for cross-arch building
         uses: docker/setup-qemu-action@v2
@@ -55,7 +59,7 @@ jobs:
           platforms: linux/riscv64
           file: fedora-buildroot-riscv64-41/Containerfile
           push: true
-          tags: ${{ env.imgref }}
+          tags: ${{ env.imgref }},${{ env.imgrefdate }}
 
       - name: Summary
         run: >-


### PR DESCRIPTION
Build additional tag with "date and time" to be able to go back to a previous version of `latest` or pin the version locally.

Do you think this is helpful?